### PR TITLE
Release 3.2.4 to show correct destination repository in log output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,9 +78,9 @@ git config --global user.name "${USERNAME}"
 git config --global user.email "${EMAIL}"
 
 if [[ -z "$FILE_FILTER" ]]; then
-    echo "Copying \"${SRC_REPO_NAME}/${SRC_PATH}\" and pushing it to ${GITHUB_REPOSITORY}"
+    echo "Copying \"${SRC_REPO_NAME}/${SRC_PATH}\" and pushing it to ${DST_OWNER}/${DST_REPO_NAME}"
 else
-    echo "Copying files matching \"${FILE_FILTER}\" from \"${SRC_REPO_NAME}/${SRC_PATH}\" and pushing it to ${GITHUB_REPOSITORY}"
+    echo "Copying files matching \"${FILE_FILTER}\" from \"${SRC_REPO_NAME}/${SRC_PATH}\" and pushing it to ${DST_OWNER}/${DST_REPO_NAME}"
 fi
 
 git clone --branch ${SRC_BRANCH} --single-branch --depth 1 https://${PERSONAL_TOKEN}@github.com/${SRC_REPO}.git

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
 # @author André Storhaug <andr3.storhaug@gmail.com>
-# @date 2020-07-03
+# @date 2021-05-01
 # @license MIT
-# @version 3.2.3
+# @version 3.2.4
 
 set -o pipefail
 


### PR DESCRIPTION
I got confused when the log output of this GitHub action showed my source repository as the destination repository and proceeded to work as intended. This is purely a cosmetic fix with no functional changes. 